### PR TITLE
Fix: make chance attribute optional

### DIFF
--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -16,7 +16,8 @@ function getCandidates (variations) {
 
   variations.forEach(v => {
     if (v.data && v.data.slot) {
-      const chance = parseInt(v.data.attrs.chance) || equalChance
+      const chanceAttr = v.data.attrs ? v.data.attrs.chance : false
+      const chance = parseInt(chanceAttr) || equalChance
       names.push(v.data.slot)
       chances.push(chance)
     }


### PR DESCRIPTION
- `ReadMe` says `chance` attribute is optional, but errors were thrown when `chance` attribute was not set
- This PR fixes so that the `chance` attribute can be safely left out