### PR TITLE
Fix: before cookies loaded, reduce was being called on empty array

### DIFF
--- a/src/toolbox.js
+++ b/src/toolbox.js
@@ -22,7 +22,7 @@ function getCandidates (variations) {
     }
   })
 
-  const divisor = gcdOfList(chances)
+  const divisor = chances.length ? gcdOfList(chances) : 1
 
   return names.reduce((result, name, i) => {
     const n = Math.round(chances[i] / divisor)


### PR DESCRIPTION
- Fixes errors thrown from calling reduce on empty arrays
- Before cookies load, there are either no `variations` present in the `getCandidates` function call, or there are no variations that meet the condition: `if (v.data && v.data.slot)`
